### PR TITLE
Potential fix for code scanning alert no. 19: Database query built from user-controlled sources

### DIFF
--- a/Backend_API/controllers/foodController.js
+++ b/Backend_API/controllers/foodController.js
@@ -92,8 +92,8 @@ exports.updateItem = (req, res) => {
     queryValues.push(id);
 
     // Construct the SQL query with the fields to be updated
-    const query = `UPDATE food SET ${querySetParts.join(', ')} WHERE id = $${queryValues.length}`;
-    db.query(query, queryValues, (error, results) => {
+    const query = `UPDATE food SET ${querySetParts.join(', ')} WHERE id = $${queryValues.length + 1}`;
+    db.query(query, [...queryValues, id], (error, results) => {
         if (error) {
             return res.status(400).json({ error });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Tunsworthy/baby_organiser/security/code-scanning/19](https://github.com/Tunsworthy/baby_organiser/security/code-scanning/19)

To fix the problem, we need to ensure that the `id` parameter is properly validated and sanitized before being used in the SQL query. We can achieve this by using parameterized queries for the `id` parameter as well. This will ensure that the `id` is treated as a literal value and not as part of the SQL query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
