### PR TITLE
Potential fix for code scanning alert no. 34: Exception text reinterpreted as HTML

### DIFF
--- a/Frontend/routes/foodInventory.js
+++ b/Frontend/routes/foodInventory.js
@@ -76,7 +76,7 @@ router.delete('/api/items/:id', async function(req, res, next) {
     console.error("Error deleting item:", error);
     // Respond with HTTP status code 500 (server error)
     // and send the error message
-    res.status(500).send(error.message);
+    res.status(500).send(he.encode(error.message));
   }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Tunsworthy/baby_organiser/security/code-scanning/34](https://github.com/Tunsworthy/baby_organiser/security/code-scanning/34)

To fix the problem, we need to ensure that any error messages sent back in the response are properly sanitized to prevent XSS attacks. We can use the `he` library, which is already imported in the file, to encode the error messages before sending them in the response.

- Identify the lines where error messages are sent back in the response.
- Use the `he.encode` method to encode the error messages before sending them.
- Ensure that all instances where error messages are sent back are covered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
