### PR TITLE
Potential fix for code scanning alert no. 35: Database query built from user-controlled sources

### DIFF
--- a/Backend_API/controllers/foodController.js
+++ b/Backend_API/controllers/foodController.js
@@ -93,8 +93,8 @@ exports.updateItem = (req, res) => {
     queryValues.push(id);
 
     // Construct the SQL query with the fields to be updated
-    const query = `UPDATE food SET ${querySetParts.join(', ')} WHERE id = $${queryValues.length + 1}`;
-    db.query(query, [...queryValues, id], (error, results) => {
+    const query = `UPDATE food SET ${querySetParts.join(', ')} WHERE id = $${queryValues.length}`;
+    db.query(query, queryValues, (error, results) => {
         if (error) {
             return res.status(400).json({ error });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Tunsworthy/baby_organiser/security/code-scanning/35](https://github.com/Tunsworthy/baby_organiser/security/code-scanning/35)

To fix the problem, we need to ensure that the `id` parameter is safely embedded into the SQL query. This can be achieved by using parameterized queries, which prevent SQL injection by treating user input as data rather than executable code.

- We will modify the SQL query to use a placeholder for the `id` parameter.
- We will ensure that the `id` parameter is passed as part of the `queryValues` array, which is used in the parameterized query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
