### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/Frontend/routes/foodInventory.js
+++ b/Frontend/routes/foodInventory.js
@@ -67,6 +67,11 @@ router.patch('/api/items/:id', async function(req, res, next) {
 
 router.delete('/api/items/:id', async function(req, res, next) {
   const itemId = req.params.id;
+  // Validate the itemId to ensure it is in the expected format
+  const isValidId = /^[a-fA-F0-9]{24}$/.test(itemId); // Example validation for a MongoDB ObjectId
+  if (!isValidId) {
+    return res.status(400).send("Invalid item ID");
+  }
   try {
     // Construct the API URL with the item ID obtained from the request params
     const apiUrl = `${process.env.SERVER}/api/items/${itemId}`;


### PR DESCRIPTION
Potential fix for [https://github.com/Tunsworthy/baby_organiser/security/code-scanning/2](https://github.com/Tunsworthy/baby_organiser/security/code-scanning/2)

To fix the problem, we need to validate the `itemId` parameter to ensure it is in the expected format before using it to construct the `apiUrl`. This can be done by using a regular expression to check that `itemId` matches the expected pattern for a MongoDB ObjectId, which is a 24-character hexadecimal string. If the validation fails, we should return an error response to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
